### PR TITLE
Added support for sub/superscript

### DIFF
--- a/lib/prawn-styled-text/prawn-styled-text.rb
+++ b/lib/prawn-styled-text/prawn-styled-text.rb
@@ -96,6 +96,10 @@ module PrawnStyledText
         context[:options][:link] = link if link
       when :b, :strong # bold
         styles.push :bold
+      when :sup, :superscript  # superscript
+      styles.push :superscript
+      when :sub, :subscript # subscript
+      styles.push :subscript
       when :del, :s
         @@strike_through ||= StrikeThroughCallback.new( pdf )
         context[:options][:callback] = @@strike_through


### PR DESCRIPTION
I made an edit to prawn-styled-text.rb, so now sub/superscript can be used as well.